### PR TITLE
download all the census tract shapefiles from USCB

### DIFF
--- a/census_api_pulldown_tracts.ipynb
+++ b/census_api_pulldown_tracts.ipynb
@@ -1,0 +1,279 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e6044826-3d5e-4102-8f3b-49260482802e",
+   "metadata": {},
+   "source": [
+    "### Getting and Displaying Census Data\n",
+    "+ Package dotenv allows us to load API keys from .env files which are in .git_ignore to keep them private. \n",
+    "    - The `secrets.env` file only needs one line that reads: `uscb_api_key = '<your API key>''`\n",
+    "    - To request an API key: https://api.census.gov/data/key_signup.html\n",
+    "    - Census API documentation: https://www.census.gov/data/developers/data-sets.html\n",
+    "    \n",
+    "- Package [`us`](https://pypi.org/project/us/) will give you FIPS codes for locations as well as shapefiles from TIGER.\n",
+    "    - Fun fact! TIGER stands for \"Topologically Integrated Geographic Encoding and Referencing\".\n",
+    "+ Package [`census`](https://pypi.org/project/census/) pulls down data from the US Census Bureau (USCB)\n",
+    "\n",
+    "The code below is based on the documentation for the [`census`](https://pypi.org/project/census/) package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "d0895aae-5c9b-4ed6-aaad-a25b72faff3b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#!pip install census\n",
+    "#!pip install us"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "id": "a4dfe31e-884c-4e10-88a4-e67c7d303aec",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import gc\n",
+    "import requests\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "from zipfile import ZipFile\n",
+    "\n",
+    "from census import Census\n",
+    "import us\n",
+    "\n",
+    "import contextily as ctx \n",
+    "import geopandas as gpd\n",
+    "\n",
+    "from tqdm import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "id": "29a31de4-f3a5-453f-a2e5-fb69d710443a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 173,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Import census API key - returns true if successful\n",
+    "load_dotenv('./secrets.env')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "id": "62338870-cb1c-4476-a1c5-8470510a87c9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "uscb_api_key = os.getenv('uscb_api_key')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afdf6dcb-8158-4ab1-a7a0-6ef6c31e7ca2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 139,
+   "id": "95f070ca-260a-486e-984b-4553cab67c5a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# This function, when given a url, will download a zip file  to `dl_folder` and extract its contents\n",
+    "# into `ext_folder` \n",
+    "def download_and_unzip_files(url, ext, ext_folder = './ext_files/', dl_folder = './downloaded_files/'):\n",
+    "    \n",
+    "    # check for and make output_folders\n",
+    "    if not os.path.exists(ext_folder):\n",
+    "        os.makedirs(folder_name)\n",
+    "    if not os.path.exists(dl_folder):\n",
+    "        os.makedirs(dl_folder)\n",
+    "\n",
+    "    # Download url to dl_folder\n",
+    "    url = url\n",
+    "    filename = url.rsplit('/', 1)[1]\n",
+    "    r = requests.get(url, allow_redirects=True)\n",
+    "    open(dl_folder + filename, 'wb').write(r.content)\n",
+    "    #print(filename)\n",
+    "\n",
+    "    # extract files with ext to ext_folder\n",
+    "    with ZipFile(dl_folder + filename, 'r') as zip_file:\n",
+    "        ## to extrat only a certain kind of file\n",
+    "        #shapefile = [file for file in zip_file.namelist() if file.endswith(ext)][0]\n",
+    "        #zip_file.extract(shapefile, ext_folder)\n",
+    "        \n",
+    "        # to extract all files\n",
+    "        zip_file.extractall(ext_folder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 140,
+   "id": "d583274e-4905-4126-aea5-e4a0722cdfda",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# get a list of all objects in memory\n",
+    "all_objects = gc.get_objects()\n",
+    "\n",
+    "# filter the list to only include instances of MyClass\n",
+    "myclass_instances = [obj for obj in all_objects if isinstance(obj, us.states.State)]\n",
+    "\n",
+    "tract_urls = [ ]\n",
+    "# iterate over all instances\n",
+    "for instance in myclass_instances:\n",
+    "    if 'tract' in instance.shapefile_urls():\n",
+    "        #print(instance)\n",
+    "        #print(instance.shapefile_urls()['tract'])\n",
+    "        tract_urls.append(instance.shapefile_urls()['tract'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 141,
+   "id": "3dd0c18c-db0c-4aaa-b60b-60794026dab2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Download Progress: 100%|██████████████████████████████████████████████████████████████████████████████████| 56/56 [00:16<00:00,  3.30it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Download the .zip files from USCB        \n",
+    "for url in tqdm(tract_urls, desc =\"Download Progress\"):\n",
+    "    download_and_unzip_files(url, '.shp', ext_folder = './tract_shapefiles/')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27ba7253-8042-4d83-954a-139ae7b2ea7b",
+   "metadata": {},
+   "source": [
+    "### Let us draw those shapefiles, won't you?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ae3d3b5-0700-416c-b9e1-de7998bd004c",
+   "metadata": {},
+   "source": [
+    "### Geopandas\n",
+    "Tutorial: ([link](https://medium.com/@jl_ruiz/plot-maps-from-the-us-census-bureau-using-geopandas-and-contextily-in-python-df787647ef77))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "id": "5e467e06-46da-4f76-8f31-f2c8d5f9bca9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List of shapefiles (slow)\n",
+    "folder_path = './tract_shapefiles/'\n",
+    "shapefile_list = [folder_path + f for f in os.listdir(folder_path) if f.endswith('.shp')]\n",
+    "\n",
+    "# Read in each shapefile as a GeoDataFrame and combine them into one\n",
+    "gdf = gpd.GeoDataFrame(pd.concat([gpd.read_file(file) for file in shapefile_list], ignore_index=True), crs=gpd.read_file(shapefile_list[0]).crs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "id": "80ac5f25-16b7-43c2-82fd-56704e5f04f2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: >"
+      ]
+     },
+     "execution_count": 170,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAzYAAAD+CAYAAADoHJAFAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABaCElEQVR4nO3deZRdV33m/e8+052HmksllSbLkizPoywMDoPA0G4agkNIQsIQAgkYEjAZmnQDIelgAu8C3nQgJHkDJJ1mCKtDGAKkHYNtbMuTPE+y5qlUJamme+uOZ9jvH1cuLORJtqRSSc9nrVpWnXvuub+6u2TVU/vs3zbWWouIiIiIiMg85sx1ASIiIiIiIi+Wgo2IiIiIiMx7CjYiIiIiIjLvKdiIiIiIiMi8p2AjIiIiIiLznoKNiIiIiIjMewo2IiIiIiIy73lzXcDPS5KEkZERCoUCxpi5LkdEREREROaItZZqtcrQ0BCO8+xzMiddsBkZGWF4eHiuyxARERERkZPE7t27WbRo0bOec9IFm0KhAHSKLxaLc1yNiIiIiIjMlUqlwvDw8GxGeDYnXbB58vazYrGoYCMiIiIiIs9riYqaB4iIiIiIyLynYCMiIiIiIvOego2IiIiIiMx7CjYiIiIiIjLvKdiIiIiIiMi8p2AjIiIiIiLznoLNKWZ8psV9uyaptaK5LkVERERE5IQ56faxkedvuhEyMtVgaU+OqUabb9y1mw1bD/LE/hnqrZhF3RkuGC5z9bkLWNqbo9aKsBaGu7N054K5Ll9ERERE5JhRsJln2lHCfzw2xt/9dBv37Zp61nO3Haix7UCNf7l372HHXcfwWy9dxi9fuog9k01GpxvMtGL6CilW9OWptSMWltIsKGee12ZIIiIiIiJzzVhr7VwX8VSVSoVSqcT09DTFYnGuy5lztVbE//zxFn708D4cYxiZbtAMk2Ny7Wzgkk957K+2Djt+/nCJSiNkphWzaqBAfyHFuYtKXDBcJuW5PDIyzb7pJsW0x+Vn9LBqoKAAJCIiIiLH3NFkA83YnMQqzZDXff6n7J1qHJfr19sxZw8V6c2nyAQO1nZmc+7eMTl7zoFDoedf7tv7TJdhSU+Wy5f18IYLhnjJit7jUquIiIiIyLNRsDlJtaOEL9+6/biFmic9NcS8UDvH6+wcr5PyHQUbEREREZkTCjYngf3VJp/47qP4rmGmFVNphDw+WqHSVGczEREREZHnQ8Fmjo3PtPinO3bxbw/tmz2W9R0ygUdPLsB1DL35FJVGiO85zDQjoiShOxdwYKaFtYC1GMeQxJaZdnzMa1xYztCTC+i8VGdJljFgjMHAoeNQTPvH/LVFRERERJ4PBZs51pNPcd2rV/KaNQM8MjLNhq3j3Ltril0T9dlzfn5xP8BkPTzimGNgsJgmEziUswGljM9MM+LJdf3WwmwSeapDj2d9B2McGu2YBPvkYdpRwgN7pp/za7lwcfk5zxEREREROR4UbE4S5ywscc7CEm+5dDEP753m4999hI07j279S2JhtNI89FkdA1y+vJtaK8ZzDfc+R3togIsWl3l4pEI7Ojad10RERERETgQFm5PQOQtLfOK/nM2/3LuXjTsnMAY8x+Geoww6FrhnxyRrFha5d9cUly7tAmDvZIOR6ebTPqcZJgo1IiIiIjLvKNicJKy1bD1Q44HdU+yvthirNBmrNHl4pMJFi8vsm2qyvC/HtgO1p31+bz6gmPbZPVlnoJhmz2SDi5d0YYCJWhv4WQe0y5Z1PWOw2XqgymVLu3hstEpVzQtEREREZJ5QsJlD1lo27pzkuw+McONj+2dbO/fmAw7OtGfPu3vHJIW0R3Xq8KARuIaVgwUyvkutFfPovgrDXRl2TzYYKqef9la2ixaXnzEcAbQiy107Jjl7qEjgOSSJxXePfrZIREREROREUrA5wcYqTQzwf+7dyzfu3sXO8foR54zX2ly2tJu7dkzMHvv52RPXQHc+xcN7K4cd3z3ZCUcjU0fOyCwsZ9g5Xme81j7isZ9Xb8fkUh6NOGbjrucONUt7spQy6oomIiIiInNDweYEGyimAXjPlcu5cHGZf9ywgx88NHrYOdbC3TsnGCimjnj+oW7LhHHCYDHN6DPcUvbzLlpc5qG904Txz7dEO9zi7iy9+YB8yqMVJbjGcO5QifF6myhOiBOL5zqMTjdZUErTX0ixc6LOjvE6U0/TqU1ERERE5ERQsJkjuyfqXL68p7MOxtzP4/sq9OZTxInlnp2TWAtjlSPbPD/p/EUlHttXecbHn+qyZd08sHvqOUMNwGApTTOMCdstUkGAxeFAtUUSJyQWlvfmyKc8hrsy3L1jkn3PM1iJiIiIiBxPCjZzZGlvDgDfdfiLN53H/bsnaYYJY5Umv/vKM+krptg33eB7D+xj/VkDREnCbVsO8p37R2hFCZ7r0Hqe3cv2TjZYOVDgob2H70XjGrhoSReOMbNb21hr6cr4HKy1KDgJWOgvBISxz4Fqi3t2TrK4O0s+pW8dERERETl56KfT4+iRkWnOHioxVW+T8lwygfu05+XTHi89s++I42ctKPLK1QOzn790RS8Gwzfv2U2SJKwcyGMwbBqrzp7TX0ixtDdHnByKKhaMgcRaLlpcxgK5wGWs0qIVJbOd0p7OwnJmtqHBk3zXUMz47JlsPMOzREREREROPAWb42Sq3uZtf38X5y0qsXn/DNbCr1++hBX9ec5dWGKwlH7G5zbaMVONNoPFNNONkN/4+7tY1JUhl/K44dFRVg8WeGhvhSix9OYDzh4qUm1GJNYyXQ+5a/vEM177smVdPLBn+ohmBOWsT1e2s/g/5bmUMj6ugaFyejb89BVSTNfbPLhn+ojrioiIiIjMJQWb46ScDdj40VcD0I4SfvjwPr5z/wgLuzI0w/gZn3fX9gl+6x/uptKMWDmQJ4wtY9MNMr7LRK3N+YvK3LL54Oz5B2fah7WGfi61VkQ7SiikPZb35Qhch7FKkz2TDWqtCGvBcQztKCEXuJyzsEhvPqAVJmQDl4FCAccxQOdWtvt2K+SIiIiIyNxTsDkBAs/hDRcs5A0XLHzW87bsn+E9/+seKodmU54Ym5l97MnWz+ctKr2oWprhoW5qlQYPHAoli7uz9OVTjFVbpDxDK0pY0Z9nphnx2L7qbD3V1uGzPKsGC5w9VMR1jGZxRERERGROKdicJL77wAh/8t1HnrNlcsZ36cr6GCDlO3TnUuQCF2M6syi1nwsfTwo8B4CH9kwR/lzPge5cwEwrJLaWiVqbsxYU2DfdxDGd9tSV5szTXBE2jXbW9iw/1AhBRERERGSuKNicBKy1fPw7DzP5NKGmkPYopn1q7YiBQgqLZc1Qkdu2jAOwb/qZW0I/ncA1wM/aPnsOlDMeGceytCvNA3urPLavE1h68wGb9z99qHmqbQdrHMpVIiIiIiJzwjnaJ+zdu5df//Vfp6enh0wmw7nnnss999wz+7i1lo997GMsWLCATCbD+vXr2bx58zEt+lRjjOELb72IYvpnOfOyZd30F1JUmxF7pxpM1UM2jc2wd7LJVD1kzYLiUb/Ost4cKc+hmPYopj0uWFTinKESxibUp6ZJcMgEbmf9TW+OhV0ZLl7cxdpl3Vy+vJuXnNHNpUu7yKdcnJ8LMva5t8gRERERETlujmrGZnJykiuuuIJXvOIV/PCHP6Svr4/NmzfT1dU1e86nP/1p/vIv/5J/+Id/YNmyZXz0ox/lqquu4tFHHyWdfuZOYKeKB3ZPsXpBgZT39K2dn8lLzujlhg9dyTu+cjf7q60jOptdvKSLx0am2TvVYO9Ug1UDBQaLaYbKaertCN912DVRp7/YeY97cgETtcObChig2uo0LhgqpZhuhIxMNzizv8Cetge1Nst7c9z0xMHZrmkLuzIsKmfYM9k4rMXzuQuLZHyPJ/ZXieNk9roiIiIiInPhqILNX/zFXzA8PMxXvvKV2WPLli2b/bO1ls9//vP89//+33nDG94AwD/+4z8yMDDAv/7rv/Irv/IrR1yz1WrRav3sdqpKpXLUX8TJJBO4fPEnW3j9+QtZ0Z9/1nM3j1W5Y9s4t2w+SK0V8c4rlrJ2eQ/fumf3Eedu3Hn4fjMjUw0GigH37po67Ph0o3PrmDtYOKz5AHT2r3nSst4cjoHt43U2jVY4f7gLY+Dn9/xcVMqwqCtLVzagGSaM11qHZmcMuyfrOMaAY1izoEC1FfL9B0coZwLu2DbOL128aHYjUhERERGR4+mogs13v/tdrrrqKt785jdz8803s3DhQt73vvfx7ne/G4Dt27czOjrK+vXrZ59TKpVYu3YtGzZseNpgc/311/OJT3ziRX4ZJ4+VAwVWvnrV8zr3ydmVKE4YnW4SxZY/+S9n86qz+vnA1+9jSXeW7lzAoq4s/3rf3tmuZJnAZVlf7lk7kf38nWEXDpe5b/cUAJcs6eKB3VNcsLjMOUNFcimPu3dM8MuXDLOiP89AMc0TY1X++D+tZt0ZvYdd5//5900EnsNAMUVfIUXad9lxsM59uya5Y/s4/3rfyOy5d+2Y4JO/eA4r+guHXaPeith2cIZzFpaf1/skIiIiIvJcjLXPf3XEk7eSXXfddbz5zW/m7rvv5vd+7/f40pe+xNvf/nZuv/12rrjiCkZGRliwYMHs8375l38ZYwzf/OY3j7jm083YDA8PMz09TbF49OtIThW1VkQu9bPcee3/vpd/e2gfvms4d2HpiJkaAMfAuQtLzLQith6oAeC7hvOHyzw6UqHejjmjL8feqQZJkpAk8NIz+8inPd5wwUJevWbgiGtO10N2TtQ4b1H5edXdjhJu33qQ/33nLm554gAW+J0rl/O+V6wg7bt874ERPvjN+7lkSRe/ecUyrjpn8IW8PSIiIiJyGqhUKpRKpeeVDY5qxiZJEi655BI++clPAnDhhRfy8MMPzwabFyKVSpFKpV7Qc09lTw010Gm7nPE7G2aOTDVxHUOcWBZ3Z2mGMfurLVYNFIiS5LANQNcsKHLPjs5tbOcvKvFLFy/iibEZLl7SxeoFBc7sL+D+fCeApyhlfc7Llp933YHn8PJV/bx8VT/VZsgPHxrlq7fvoBUlPLBnint3TtKbC3h8tMrf37qdLftn+K0rlx31miQRERERkac6qq5oCxYsYM2aNYcdO+uss9i1axcAg4Od376PjY0dds7Y2NjsY3L0mmHMUDnNf7/6LC5f3sPHX7+GH/7eS/nb37iYajPkVWf1s255D5nAJeW5BE8JCVv3V7nyzF5+8cKFfPJN5/LYaJWRqQYvWdHD6sHis4aaF6uQ9vnlS4f58jsuZbTS5J4dk7Rjy1i1xcqBPO0o4tv37uIXPn0TD+/VBp8iIiIi8sId1YzNFVdcwaZNmw479sQTT7BkyRKg00hgcHCQG2+8kQsuuADoTB/deeedvPe97z02FZ+G0r7Lb71s+RHHVw4Uec3Zg9zyxAHe9uW7jnj80qVdRLFlYVeG37xiGX/0fx7k3l1TXLmyj+0HavQXTkyXusFSmv/3Vy7kD65axev/5614jsPeyTpZ36W/lCGebvGZf3+cT//S+QwUT/3OeSIiIiJy7B3VjM2HPvQh7rjjDj75yU+yZcsWvva1r/G3f/u3XHvttUBnP5YPfvCD/I//8T/47ne/y0MPPcTb3vY2hoaGeOMb33g86hfg72/dftjni8oZrjp7gKvPW8D/88vnU2/HvPpzt3Dvril8B9phyNrlPSe8zkVdWf7q1y6i0gxpRgnFbMDtWyfYN9Xg5icO8ta/u4NK88hNSkVEREREnstRBZtLL72Ub3/723z961/nnHPO4c/+7M/4/Oc/z1vf+tbZc/7wD/+QD3zgA7znPe/h0ksvZWZmhh/96EenxR42z2TzWJUfPbzvuFz7vl2T3PzEgdnPSxmPX1jVx1/92kW84yXLuGfHBN+5v9OpLPAcfn3dUj7z5guPSy3PxxUrennDBUNUmxFb9s8QuHDOwhKXLesmAf74Xx6i/fM9p0VEREREnsNRdUU7EY6m88F8EieWO7eN85IVvc998vMwMtXgRw/v43sP7Jtt4wxQzvr8f2+7hEuWdgMwPtPiQ//8AIW0x5+/8RzK2eCYvP6L0Qxjfv9bD/D9B/dxyZIu7nnKHj1rl3Wz/qwBfm3t4iMaKIiIiIjI6eVosoGCzQnUDGPS/ovv/vX//XQb//HYGHdun+Cpo/fSFb381suW8Qsr+zCm0xTggd1TpHyHBcUMpaz/ol/7WEkSy+dv3Mx/PDrKdDOiNxcQxpZH93U2aF01UOCC4RK/+dJlrBwozH49IiIiInL6OG7tnuXFeaGhZrLW5i9/vJkbH9vP7sk61sKirgxdWZ+JWkjgOnz4NSt598uWd/aosfDo3mkGS2nOHy4f2y/iGHEcw3WvXsnYdJNGGPPdB0YopF0uHC6DgUdHptk0VmXTaJV//K21FNMnTygTERERkZOPgs1JrNaK+NqdO/nq7TvZO9XAmE5jgIlam/MWlfidK8/gvJ8LLsPdWQDOXVSag4qP3l/80nn8x6NjfP/BERaWs2waqzJYCCikPFpRyEMjFZLkpJpUFBEREZGTkILNSejLt27nJ5v288RYlcFimjDuLKb/xOvP5ooze3lg9xQ/2bSfr921i3MWlnCO4140J8KyvhyJhcdHqwCkAx/Xcxmvh/z2lctPinVBIiIiInJy0xqbk8jBmRa3bTnI396yjbetW0I28GjHCTsO1viVyxazsJyZPddaSxhbAu+oGtudlOLE8vDeaTKBS+A6BJ6D5xoC11GoERERETmNaY3NPDBRa9OdC/jBQ/vYNFpl53gNz3W4cHGZf3nfS0h5nfU4cWIJ4+SI9TnGGAJvfs/UPMl1zEm7FkhERERE5gcFmzmwv9rkX+7dy4XDZf7s+4+yuDvLR//zGs5ZeOS6GNcxuM6L76QmIiIiInIqU7A5QRrtmO0HawSe4Z1fvZvfvGIZT4xV+eHvvYxSxlc7YxERERE5pvZXm2w7UOPsoSKF06DDrILNcWSt5dGRCrsn6xyYaXP2UJEd402+e+1L6cpp7YiIiIiIHD8zzYg7to0zOt2kNx+wdnkPvjv/12c/EwWbFyBJLNsO1silXMYqTR7aM83f/nQbf3DVanrzAfV2zJoFRQaLafqKKdYMFTUjIyIiIiIn1PK+PB9cv5KbNu3nzIHCYaFm64EZzujLA3DvrklW9OUoZjq/eG9HybxsUKVg8xzaUcKGreOMVprc/MR+fNdh485JLlvazUtW9HJmf55Ll3XzposWMVlvY4xhqJSeDTL9hfQcfwUiIiIicjp7+ar+I449GWomam3u3zXFTDNky/4ZXn/+Qu7YNs5rzh6YbWY1X6jd83O4f9ckB2farBzM019I4zmGZpSQTykTioiIiMipo9aK+LcH93HB4jIrBwpzXQ6gds/H1AWLu444lj+F700UERERkdNTLuXxy5cOz3UZL5h+QhcRERERkXlPwUZEREREROY9BRuReSZOTqplcSIiIiInBa2xkVPSnsk6o1M1HMfBdVwsYICf/eEQA1iLOXTQPnlS5w8Y0zklsZ0/d1ptdC5invyT6exZ9OSFrbUYY3iyL4cxBovFwZAceuxJ1lownasZ02kl/uRzOo+Dc+jXD0nSee537t/LlSv7nrbDiYiIiMjpSsFGThlhnMz2Z79j8wH+6eaHyRfzhAQk1uIYw9b9Vc5eWOLhPVOsGiziOJDxPWrtmPFamwXFFGFsqbZCKvWImXbEWQsK3LZlnOV9eQYKARbDQ3unqTYjLhouYRyD5zjUWhEPj1QYKKbwHIcFpRRgmGlF9BUCJmshhbRPGCekPId2nFBrR/iOQznjY4EoSbhz+yRLe7IALO7KYAzU2jHZwMUxMNOKmW6EbBqtsnZ5F7vG61x+Rq9ai4uIiMhpTe2e5ZTx5995gJnIMNyVZsvYNGMTVRr1BqXeXhILo9NNUp5Ddy4gsXDPjgkuX9aD44ChMyUTJ5ZGmBAnlqlakwXlDA/sqXLR4jK1dgQY0r5DtRkRuA6Yzl5HhZRHAvx080EuWdrF+EwbzzF0ZX0cY6i2QjzHIYwisimfXMrj5icO8tIV3TjWUo8shbTXmalJ4LYtB1h3Zh/WJnjGYIxDbC0WSxglJBY2bJtg9WCBYtpj28EaLzmjl7etW8J4rU1vPqA3n2JROcOmsRn+z717OGuwwOsvGJp3PelFRETk9HU02UDBRk4ZP3pgF39z226SxJILXKL6JHeNWl61qpvIdmZUytmAqVqLbNrnwHSDlGeY2jtDby94mRx7qjGOMRQzPv0FH9cxjEy36S+k2DRaYXF3jrTvMtMK2TvVoBUmnLOohGcMj4xUmGq0uXx5L1ONNrnA5fatE1y8uEw6cEgSy+axCtlUwLKeLJ5jmG5GuMbgew5xYoliSzHt0wxDxusRC7vSNJptEmsoZHySBKxNcIxDO7EkSYLrOhhjMFgeHamysCuDBXzHUMr4VJoRW/bPHAo8Kd73ijP4xQsW0pUL5nrIRERERJ7V0WQDNQ+QU8Zrz1/MyoE82cAlcC1jo53MHiUOtUZEPu0SxyHlrE8URhSzAY7rsWxVN6WeXjKZDGnfZUlPjnzaY6bZmaFJeQ61dsxkPaSQ9ojjkJHJJoPFNCsHi9zyxEFu3TrO4p4sFy7u4uYnDvDA7mlGppr05gICz+GObZOkfI+zh7oYKmfYsG2CvdMtZpohmcDDdzprbBzHENmEyBp8Bw5UWiQYMoHLTDsishZrOutuXMeQ9V08EpI4ZMfBGTKBSyFwcQ34nsMNj+2nHUacO1TgF1b2MlhM8d379rLuUzfyFz98jJGpxpyNV60Vcf0PH+OmTWP86317OMl+xyIiIiLzjNbYyCnl7AUFJqpNwiiitxsG0x7jtRZxnJDPuCTWpd5KyHmGA7WYnkKKJLEkSUTiOHTlAppRTMpzMI5Hq9kiG/hsPVDjsmU9jNdaFFIePYWAejuhGbUZLKbIBh7NMKYnn+LSpV2zjQUGS2n2TDa4bEmZgzMtqs2QwHW5aLiINQ6zPQfikCh2uGvHJOuW92CwTNZDFpQz5FIek+MH6OntJ4njnzU2wFILLWnfxQdyzSZDi/tIrMGJYgLXcMmSMuWMj+N0uqnNtCJKGZ9mmHDTpv38y317+fW1i/nAq1ae0HGK4oRrv3YvN206wG2bD9KVdVnak3vaDXFFREREng/N2MgppT+XYrLexnNdunp7KJW7yad9CpmAarWCjZo4xExNTNKVD2hHCVONEOdQZzLHdD7Gqi0OVFuk0ylu3TLOqsE8jrEEnsMTY1UOzrSYbrR5bF+VRV0ZunMBWw/UaEcxrmMYr7XZN9Xgjm0TGGPwPZdN+6r059OAxXEdmmHMg3ummGmGNBOHx/ZVuHRpF9VGi8l6yBl9OeIkAQyFrl6w4LsOrmuw1uCSkAk664KMcega7Cax0Ajb5FMeDpBPecTWEieGMIYlXQ4DxRRXremnN59ieU+Ou3dMcP33HmTXeP2EjdONj+8nSSwr+vP0F1NM1kJim5yw1xcREZFTj4KNnFKWDeQppH0a9RqNZo3pepsoTsilXEyQIzQBjuOQzmZwkgjHRpSzPrgenjFkPIc7t0+weWyGfMajFVmuXNFDFFta7ZgkgVUDBYopj3yqM+GZDTzygceank5TAc9x6M2naEUJGd9lf7VJGCdcuKQL1zGUswGucQg8l5ec0UMu5ZEJXFYPFsinXNKBTynT6b5WTPsA+K4BY0mAxCYYEiydgOMZiJOElO9gjCXj+1hrSayBJME3Dp4DvklwvTRRGNGMElwD2cDFM7B9vMFf3riJ2zYfOCHj9M9376YZJWzZP8PeyQbduRRRrGAjIiIiL5yCjZxSXAOYzszGbbuamHaFwLXEcUySWCqNkJHpFl4mizUuge/RaMfsnmjQCGNia1lQ6rRNzgcermO4des4YWwxrtNZB+IYFuQ9au2I1YMFfNcQeJbES5NYaMcx2cBhzVCRRhjTDBMm6yF3bZ/gif0z3L1jkv0zbe7eMUktTKg0IxJrKGYCHGPIpzwyLlQaTZphgk0SbNIJVp0ZnM7da/VaBZKYuNXE8zrraqDzl9pzHVwH/MAhISFKLK2k03EtweK7hthapuptHMAxDrsO1Pijf3mQv75pK/V2dFzGx1rLt+/dwyMj0+QCl6FSmq6sh+PAP925+7i8poiIiJwe1BVNTikbtx/kr2/eyvbNB+nrc/GyRRID9++a5uKlXbQj2+malvJmN+dMbGfGwxhD2nNpJwkTtTbVRshQVxYDTDdCAtcQW8DCYDFFmFhcByZrbTKBi3toJ82JWkhvLsB1DWOVJmDIBA71Vuc2tVaU0F9IUWvH7Bivsaic4YE907z0jB7qYUy1GbKgmObgTIt8xifnGRLj4B7aLNRxgKRzO9v9jx5gDHj5GQWCIE2cdDqm4RhILFHUJghSxInFg0ONCRzq7RjfhaxjibF4vg90Znh2TTX59cuX8uuXLznq97/Zjrlr+0GMY0gOdXmzgGMscQzf2riHMLFEcULGcwBLHEa0jIO1hteft4BfWXv0rysiIiKnpqPJBmoeIKeUfZN12lFMdx9kCgUiHDKuw2XLu6i3Eh7aW+GypV1MNtrsmqhjMCzpylBI+7TiBN+1PDE6w6KuNNlimjhO2DRW5Yy+PPV2THfWJxO4RBbGa20e3DMNwNplXRhjaYYJpYxPvR3RCBNaUcITYzMMFFMs7cmRDVwa7ZgnxqocqLa4YLhMIe1xyZIuKs02pWwKxxhiYEE5w1Q9xEl51JsRxayPISZJDMbpzB4t6of2fjoBLYqJwhZBJotNLAaL4xiwCdiEXbsnGBruoRVGYBMyjkOEJfACkkOzQpCQWMvW/dWjfu837avypZ88xnQtwvFcEptQnZig3NuNtWBwaMUJnuuQ8hLiOMIxPqGNcExANuVSax2fmSIRERE59SnYyCml2o5wjUNlCopFQyu01JptSmmwOPQXAsLY8vi+CqsHCgS+w46DDdYMuWSczl4yC7syJEnCPbunADh7qEAx43Gg2qKYctl+sEVXzuehPdMMd2XYPdngkZEqly3topnEtKOYh0cq1NsxV5zRQ9538H0PzzFEscWJGywopujOpdg71SQbOPQW0vTkA8B01gPRua+slPGwQC7lksQxxji4jqEdRkRhm+6ubgqlhNZMDbfg4wcBBphpRfhuQsr1iKOIrZunWLQkS61eJ5PL02y1cXwPJ7G0oxae6eyFY62lnA4YrbSO6n3/1l07uOHRERI8ZhJL2YBxHMrdJeJ2hHEcHM8hOLQZanW6QpAKcFMOmSDNhYu7uebSYfoK6WP57SAiIiKnEQUbOaUcrLWxxjC8tId2DFO1JgtLafbPtMimHIbKGUYrDZb35nlgb4U1C4pM1ts4ZKlMHmTHAVi+tAs/8Fi7vAsSC8bhpk0HOX9RiVwAhUyWqUaEBRZ2ZVjYlaHWinho7zTL+/Lct3uKwO3clrZ/ptVpRBC4JMBZg3nqbcNAKcVMK6KQzpL2XRphDBgmam3SnovjQMp3iJOEXOBRrVTI5IpY2ykpcF0CL0uSJHgmweTzeK5LDLSbDfKpNEkCxgEHl+VnlnAN7JuJCeKEtNcJMbGND/03odlskMnmKWVdJust6q2IbOrI/0WMTjfZM9npoGZM5/N/vW83ac/F8yHteSTGwTGWyCZwaAPR5NBsUBxGRO2Y887oZlFXkbOGily6rPeEfY+IiIjIqUnBRk4ZcWLZtK+K5zqQxMy0YnryaW7dNsFAIcUj+2bwXdNpBPCU50WJpdKy+Lky55VdQkunRTMuM1FEJgUvX9lLvR0ThTGbxyqsObTh5b6pJt35gL1TDcoZnz2TDdYMFtg33SDjBbTDmELa4+yhIg/tmWa8FmIt7Bqv05sPaIYxuZRL1neJrWVkqslZCwp4xmCMxXEcWpHFeD7GJhjT+doiEuLEOdQRzeC6LlGcYI3BC4JDTRQcJibGyWZyYC0bdtZZsqBAmFhmWiG0p8jncvh+gHUMkwfaRF0TdJUH6M8FZAL3iPe4Gca8+69vpK+nyONbK/SWoKeviwM7KyxcVmD/3kl6F/QBCdWZKbKpIsZAksSEzSbJoVvk/vjNl3LR0v4T9a0hIiIipwF1RZNTxn07x5luxp2OYZElG7ikfUMmcBksZTBA2ndZs6DIkx0znEMJx2C4Y8cUmw/UZlsnB67BAlFoO22cbQvH93BdQyuyjFValLMBlUbImsEiPfkUI9MNImsZq7ZZ1BXQjBIMljix1NqdjT+7cwGLyhnSrqGU8YnizoxJyjOc2Z8j7TuENsZ1HRIL1iakU5lOrU6nK5vreBgsruvgeS6WztfdaQVtSGwnFIUtaLfbJHFEHSilXVKeQys2JA3Ysr2GTeDWxydoR3DXKDz4+BhnFkKMMUe8x1P1Ng9NQavd5MzlBQrFgDBsUE8gjiNyXRlsHDJTmWLDrohms05iE6Io5sC+FrftadOTSbhwSd8J+I4QERGR04lmbOSUsWpBCZvEWBx826Y2U6ceFFjTlybEctnSbjYfmOHRfRUC19COLc7P/fC+Z6rJnqkmLzmjm2q1RiadZu90iyU9WRKbJsFhRV8O13QCyr6pZmfdTmI5UG2xpDtLby7gF1b20QhjVvSl8F3Dzok6Gc8wMt3gosVdGODmJyZwnM4GmwDnLyqBoRO6DESxxTeG8NAsx8TUJMVyD9bGeMbFhiGJcTCOxUbQbNbIFQoYx6E5UyOVzdDbV+KJzdMMDnS+vno7oZB2KKU90vkClXqVsN3ggiHYNdI5Zx/w9vUXAdCOEp4Yq7L1QJWHdk+xbXSCK5dmCPw0sU3I5AsQxgwPhQTpDGErJDGGXK7AS4ZncIxh3+4pil2Gx8PO9XftjJ82NImIiIi8GGr3LKeU//qt+9hfC2m0Y3KBAzhYmxBbQ70dU874TDbanYX8h9o1JwkU0h6V5s86crmHAkfWd6mH8eznOTfC9zNMNkO27J/hguEy4zMtHtpbmX3uBYtKBJ7DXTsm6cunGOpKM1Ft47qGxeUAz/exCcy0I6YbId1ZH88xndewFsd0ZpA8xwFjicKQdJA6tCWnwZjOLI61UK1MkS+W4FC7gf0jB+lf2I9NIpIkwRx6ZMvmSXYcqm9Vb4p0q4XnQraUwvezYBPiOGF8vMrvv+E8XrZmEd9/cIRvbthKkkR4jmVqokm5nCKdzUMUYz0PB8v09CRBOmBipMmiZT0kcURkE2q1Gr4XcPueJqvSUG/CbuCCPJQGi3z+1y6jK5s6Yd8bIiIiMv8cTTZ4UbeifepTn8IYwwc/+MHZY81mk2uvvZaenh7y+TzXXHMNY2NjL+ZlRJ6384fLJEnn1q84sSRJzK7JBvUw5p6dEzSimLt3TLLtQI27d0xyx7ZJ9kw1CGPL3TsmeWykwv27prhj2wSGzmxJ57wJKs2QqN2mHScUUh5nLSjgAD0Zl5zfmYG4dGkX+6abVJoRly3tpph2SbmGZX05lvTkaESANTTjhLt3TJJPe7iO07ntDIgTiK3BcZzO/i8YPNel2W7zyGMHaLcbncBiDK6BjSMRNunc7mYcQzbvYeOIHZsncD0H1/OIgaHhnwWIbNzCS8HIFHiujzEJxnWIbMjDVfjbmx7jHV+6kd/7xv3cvrNKOuXheT49vVmymRwWg/W9QzNLDsVyF5lUjmobGs0GjbDNvq1Vto0m3LGnCYCJoJCDpYCTgd60JYmTE/idISIiIqe6F3wr2t13383f/M3fcN555x12/EMf+hD/9m//xre+9S1KpRLvf//7edOb3sRtt932oosVeS6NdkSU2E4DAdMJC0u6c0w3Q87oy9MOYwAWdWdoRjHNMGaolKYRxly6tIsotrTbbSIcGmFM2fe5eHEZC3RlffZum2Hh8hJJkhA8GUaMw1lDZRLb2fhz1WCBRhiTCVz6S2myvkujVqVl0riOQ2ITbJLw0hU9NNoRGd+hEUZY65DyHBwDnmuo1+uk0mms49Cu1RgBinurLFwSECfgOw4vX92LNZao0cT4KQrlMo51GFycJ44SHAdcxyGTzfPyZQHGcTCdzgKUyzHtMGL/9hkWLe8il8lz5RKDcX1I2pyVhseasG1LlQpw7nAa6wNJhHUMxkI7jKjNVPEDnxbQateZnoRNTxmT1SlYOFziP1+4lF+8eBHT9TbjM01Kmq0RERGRY+gFzdjMzMzw1re+lb/7u7+jq6tr9vj09DR///d/z2c/+1le+cpXcvHFF/OVr3yF22+/nTvuuOOYFS3ydKy1PLR7At90OqTNNNtUJw/iOpALXAaLKWZanWCzZ7LBdCOiFVkm6yFh1JkFKaRcMoHHtoM1AtehFSVs3DXFvbumiKKIx9tA1NnjZaoe4jsQRgmNdsy9u6a4edMBHANxknDzEwfwHEOlWmXv7iY7xus0w5h6q00zjPFch1YYk1hDyvNoRp3a4jgmjmIC38PBwcEyVWnxmrP6WLy0Fyy4T/Z1MwYSg5/JYRyHqB3SjkMyQQrHdTl4cIKJ/eO4jsFPpfB8n8rUFNbGtNotvMBj4fIi7bjFzMw0XipFs1kjjqC3L+C8PJyxokgG+OnuJrVGHRvHVKemqFamcD2XfD5PdTKkOwN37YOx5uHj8tuvXcpf/cZafvHiRQCUsgHL+4ud8CkiIiJyjLygnyyuvfZarr76atavX3/Y8Y0bNxKG4WHHV69ezeLFi9mwYcPTXqvValGpVA77EHkhjDEs6O50PBufabHtQI18schjo1U623NCKevxshU95FMeg8UUC0ppCmmf+/dMAzBeC8lnAs5bVDrUGe1nf0VqIVy+KODGLdNUWzH1dkwzTGjFlr5Cp2HARUvKREnnFqtyxiOKEqYPNnGBFX05+nI+U82ElO+x9cAMrdgS2Zg4ScgELo0oJsbBc11wPBKbUG3EDC3spRkmnVDjGmKbHHodSwK0o4jYgmMMjtO5/cwY6Onppqe/B2uhWa/RbjfI5bI41hA1W0yMVbAuGOMQRxE2TrhzJMa64HgBvYNdVCcrdOU670Gz3qTWblAsFsnnijTrNW7aNsOWGjze6Jwzdej9+so1w+z41NX84rqzyaT84z38IiIicpo76mDzjW98g3vvvZfrr7/+iMdGR0cJgoByuXzY8YGBAUZHR5/2etdffz2lUmn2Y3h4+GhLEpn1oVevpBV3+mGsHCziez4DQbOzHsQx+MbyxJZxhspphruz7JtuzgYRgMdGK9z0xEHu3z3N7VvHSaxlRX+OFf05Jmotdlbglat6yQUOmcAlTiz37Zo6tKans/bGMYZi2uPSJWVyKRfPgW1AIeWC49COElKeQ38+TStKaIYJie20aI4T8BzDtvEaYWyxBrIpD89xCHwHHAdrLWGz3pkZihNcY/CMIXAdZup1SGKMsSQxVCYnqDWqkMSkszlcN8APMuzcMc0d+6G7v0TUbHHf9hnuHLUkScLqHDjGIyHBdR26+3sYXFDivF7o6+vFsZ2dP8fHp4mikLPzsDgF5aeMw0sXGV5+ybkncORFRETkdHdUa2x2797N7/3e73HDDTeQTqePSQEf+chHuO6662Y/r1QqCjfygvmey4reLLmgExSstaR8DycKMX6KJI4Y7gfXWJLEkg9ccoHHmgVFsr7LJUu6qDZD2rFlotYmSixb9tfoyvqct6iEY6DVjnFch7TvUm8nFNMevufQbDaYil36cykim9CKEibqIYuW9VOqTAIwWmnQlfWZaUW0ooR8yiflORgDTtyZZTEG4thiDLjGYbLRIuvGpNJp6vVpPC/NT3c2uHKZSzqdIYpjXGsJE0sml59tOmBcl1JPN8ZCFIUYaw+d69A/4LHQ83Edj8S4VIErFgX4rs+CwQIYlziJqM9MkyuWabVb9JSLWAdy+TKt+gzpnM+de8PZ9/7KpRmmKw0yDrz10kVq6SwiIiIn1FEFm40bN7J//34uuuii2WNxHHPLLbfwV3/1V/z7v/877Xabqampw2ZtxsbGGBwcfNprplIpUiktIpZj59xFZUYebWDjGItLbSbkvsmQV67sxjguxWI3+2dCNu+f4dyFZe7cPgHAo/s6z1/cnaWU8ejO5XEP/Ww+3JXlwT3TnD9UxHFdfrrlIADLenNUmhGj0y0812FBMcWBapu0Z/A8Q18hTRgnbNgT8pIzEgLPYXymxdh0k8TCsr48tWZMIePjuw6tKAYs+bSHwdBsNimkfaqNiLgVErZDokMNEJqNGXzPwxiHdpKQhG0y6QJR2OSGrZ1bOl9xRgnf9/D9NHES4rkGrCGVzWETiyXBD1JcUK7jBj6u7xI2Q3wfjOOSCcrEQDaTI04sJjGdxgmpDCZsAZ1gc1YWjOORyab5rStXsP68JSdquEVERESAoww2r3rVq3jooYcOO/bOd76T1atX80d/9EcMDw/j+z433ngj11xzDQCbNm1i165drFu37thVLfIsfvmyJdTbbf7X95+gCjSBITr3XTqBTyNMKGV8FpYzbDkww5Vn9lBpxsy0Qlphwq6JOpcs7eLuHZNcvqybjO+wZX+Vc4aKVNsRk/WQM/tzWAuLuzMErqGU8YgtxGFMI4woZtLUw5iUm2BswjlFqMzUaMYOS3vzFNIBAI4B3+vMLrnGkE+72AR6cx4JFtfzCHwX0/bxXch29ZGQ8MpCjOO6mEPraoxNiBKHhATH9wiAAehs9JlYHAcc1yMJI4zXed72LeNULZy5OEO5VMAPOmtzIGF0dIp8FlwvTS6XA8fBNRBjac7MkM7nsLisSneaDPheQBxHBK7hsjOH5mTcRURE5PR2VMGmUChwzjnnHHYsl8vR09Mze/xd73oX1113Hd3d3RSLRT7wgQ+wbt06Lr/88mNXtchzuPyMAf6EJwBYQGdBu7UxFod6OybtOfQVUvieyy2bx3nZih5819AMY9K+S8rrLD9LgMBzOG9hmVaUsGnfNDPtzo//y3pzPDo6Q28uIPBc6u0IXBfHcTotpx2H/dUWA8U03QO9jM+08I2l3orwHQg8l60HOre5FQPoKeZohp2GBPm0TzsK8WzEnpEJMt0lppuWdNQgmwrwXA9rO7erYcAaFz/lYpMEaxyuXNUNSYJxPZq1adxMnpTjMDIyRW9/Ds/3KfdBlwXPc9m1rcqyM7tw3YR0kGFgMMAYl7BRJ0piHMcQxxG+62GCgCgMSaVSLFrk4bqdUOcbuHi4TDGjRgEiIiJy4r3gfWyeyec+9zkcx+Gaa66h1Wpx1VVX8cUvfvFYv4zIs1ram+Ov3zDEe78zwj5gGTA1Pk2pt4eurEczsriJZWExxUwzxHEMd++YZLgrw+7JBpv3z9Cd8ymlPS5aXMZgqbcTVg4WgM4C/9FKk/GZFn35FNYmlNIeiY0ZyAc0wphmlLConGG6GeE6ht2TddK+x2Q9ZEV/nno7ZlE5QybodEGL4s7qmHYU0gw7x1wM9RosGPaZbERkUw5YSxS18Vwfay02TkhsgrEeOIbEgm8cEmOJw5BMrkhswWJYsLAMxgEsxXIZYwFrWbq82AlIdJ5vwwTjAb4PWJIwZGx0mlLJJZMtgIWZ2iR37IVfWFHANR7ZTJp3vWLlHI24iIiInO6MtdbOdRFPValUKJVKTE9PUywW57ocmceiOOH3v3oDd2yOWH1mF46BdqPOjt0t8oMFBotp7tw+zlA5w0AhRStK2F9t0QhjDIY4SThnqEActXG9NIHvUGmE+K6D7znEcecWr3orIpfyMCTEcULg+xgDzTAh7Ts02jGRhYznUA87LZqNMcSJxXPAcxwMlijh0MyIJbYJ+cAlSsB3ILaGVhwTOBbjOITNGul0hiROeGRrhTUrunA9F9cxJInFdUxng04s1jFE7TZ+kCKK2p39bsIIz/dxbELiuGAtYdgm5aWISSAB6yQY43bW+tRr4DikPR/jBxgHksRSnZogSKe4dWeTj61fxG+uP3+uh11EREROIUeTDbRDnpyyPNfhN9dfRBoYmWpSD8FLZakBPWlDox1x8eIuevMp7toxie85nNGXY3F3lulGm3MWlmhGCbftmOGWLQfZN93ZZLMRxoxXW51OZsaQCjziOKEVxlTqbTbummK6GVNpRlSbnY0490w2aEaWkekGd26fBNsJBr7rYoHYQju2+I7Bczu3qRnHYIixSQjGkgtcDBYPh1yuSBRZXNfl/NU9WBySJMbGndbVURSDY7COQ5JYHN+DJKJarWLjmCiOsBYSx8PYTlgyOMQ2xsaWiakpWo06hgRrY/xMhjhpEUadWpIoIolj8uUyJraUgGai/52IiIjI3NFPInJKW7Ooh9f+wjIGShl8z8V1Hc5c4NNuVNh6sEYrTrhr+wRRYrlj2wSxtYzsmqIdWxJryacDCimX8xaVqDRCVg8WOFBpkkm5ndbMQNp1SPke+XRANTKcO1SimPbI+Iac27klrZj2SfkOC8tZFndnieKEjN/ZB8d3HZphZ2+baisi5Xl4jsF3HDzXI7EGz1h2bT3II1umMSbG2oT61DQ4DsYYAs/guz7GmM7tZQaIYuIkgiTGYjDGpVTu5sdbq9y2q4nrGqJ2C5sktJt1Ht5epRm2MQayGZ+UnyEMQ2wUs3vzFA/sSWg1G2x+fJyZmSmSqI1jIZXJc8nKMrsqESfZBLCIiIicRnQrmpzyas2QP/vew4xMVMALqLcScm6MdQNct7PhZeNQ04D91RbFjM/kTItSNiBMEnK+x107Jghjy5oFBXpzKe7bM8VZCwpkfIcotqQ9h2Y7wrgeM62IXODgYalMTpLr6mG6GYIFzzUUM36ngYHv4hpwsEzWWxjHY/vBGS5YVMZ3wTEOjzy6nyWLAtL5HElCZ2+YOAbT2fvGOA5h0pnlMUmCNQZwSOIQx3WJw4habZpUKkM2m8XahHYrJE4ifD/AMS6JjWm3Q9phi2y2SBTWadXbFIpFxicqhDG4LhSLKYyFW3e3WOFA/wKPxCZk8iViXFybcO0rV3DJsr65HnIRERE5RehWNJGnyKV9/uvVa/BtSCu0ZAKH8QNVfBewCQkWxxgqjYjH9lW5c9sEmcAj41qKgcveqQZDpTSXLi1TTHvYpM2q/jxJ0mkikA48HMchnQpoRxE9uYCJfRPs2jpJsacHxzFkAo9syiPtu2zcOYVjOn/5RvccBNOZmSmlfc5fVMb3HCLb2SMq7UC73cZacBwHx3Fw/YDExrRaDSzgG0vYbhPHCUmSYC24rsd/PD7OgX3TlMu9pNM5rDVgHBzPJwgy2Niyffsk+0crpDMZyqVOkwTfy4AL9XqFKIJHq2BiyKVzOMZwlgfDSwsYxyGVymESS+BCTz5DXyEzx6MtIiIipysFGzktlLMphvIe2cBhtNIk01MmsbBz8zgukHYtCbbTAto1WMB1XX66dYJWlDDUlSXvGwIX9lVjNu2fYaLWAmu4b9cUlUZItRHSjiyVRpu+BWWWrepl71STVpTw8J4p4jhhx3ids4eKOAZim9Az1E0rSnAdQz2MCRNLEicYa6lOTbFwRQ/l7l44FGxsAhYwjo+fyWNwMMZhZqbCti1TOKYze5MklssHoX+oC3uo85m1hnqlQrtRZ3TvJHgugwtSpPPgYA51TrNE7RZ3j0G9Bn0DRS5dAL0DJeLEgudTGvQxXkAqnSeJIjxb54Lhbj795vNY0puf24EWERGR05ZuRZPTxqbRaZ4YqfDQ5i18874604eOD9EJC8PDOdqJQ6WV4LsO28aqXHFmN63OtjW0Wi3a1mVhKUUrsrTihELKoRUZJuotHtpbob+QYklPFqzF91wa7ZhixqMdWTZsG+eKFT1kHEs9tqQcF2tj2onBGINjYLrRpjeXwnEMGIuJYxIMzqFbzzCGWiuhGUWUD+0XY21EElviKCLIZOjcswaO60BiMVia7ZB0kAZiGq0GTuLh+IBxaDebJMRUpyK6enKdvXCsJZVJY4B2q4UbBNSqFUqlMnTiFBNj4/y3X72cCxZ3k1hwHXNiB1REREROeboVTeRpdOfS1KOE81ev5H/9ztrZ4yPAPqA5VWN6ukpsLaOVJmvP6AbHYedEnXo7hnYNW63QiBKqzTYp3yG2hkdHK7PXshbu3jGJ6xhu3zqOBRrtGM81/MLKztqTm7dOAgbPM53W0Q40o4RWlOB7LtVWRHWmykythXVcMC5xHBHGEVEck00ZujL+bJCwuDiuh+N0NuhsxxbXcSCBxFqscQi8gAQLthNKcBLqM1VIIA5bbNgd8XAVmo0amVyObDaP6xgmJqbYvLNBFMdk8jlsDJXxCZaUA9726nO4cEkPxhiFGhEREZlzmrGR086+qQYpz/DE/hoHd23m0z8aJwZWrezBsQlN69COE/K+S5hY4sQyMtXg4ESDGWARsGZ1H/uqLdK+iwHqYczDeyusXdZN4BlaYacTWhzHtGKLpTPzUU8cwjihJ+uT8R12b59gyRm9VFsx1lryKY9GGFNI+zTbIRnfoVGvE0VtSqVuWlGM7xgiC7bdIJXtNBWIk4jYGnzXJQqbBEGaxNrOvjhRSBhGpIIUrXabW7ZXOTsLuSKUSz20whYPbJvhzAGXcleZOLHYOGZ0xzRDy8udttPWdjqrOfCOy4a4Ys3SuRxCEREROU1oxkbkWRQzHl25FIm1rL/iUr7x4cvZC1ibUIsNKRNx9/ZJAO7fPcW2gzUWdmdZvKDAJQMOixemiBJLTz5F4DgU0h4OcN7CAo6BSiNkx3gNC2BisoHXCUrZDAuKaSarTfJpn3ZsWbi0h0YY45nO7I3nOriOodZsk/YcwnaLW3c1uGMkpt6YwTeW2EYEnkOQydCOErAJDi4egAHfT2FtpyGCjRNc18dPZUgAbMKVywsMDndTKncTA4lNuHhlmSDw2bd3HM918FyXhSt6cFwXx3Fpttvc88QkFy/p5/LVS+Zm4ERERESehTfXBYicaLlUZ23K5ct6MAaG+noAWH/2AvoKGfIe/P7r0vz5t25j1aFF860wYUEpTaPtkvIcKpUJyuUeKmFIpWnJpX18LLGBrlxAybc0w4iDtRjXNFhYzjBda1LKpTlrQZ7JmQblXBroBBrXMYRxxMz0BKl8GeMaLJZWswl0tqVxMEQ2odVs0kiqZDNFtm6ZYsUZJYxnqExNUe7rI2rHuMYwMT5Bd08XYIijFjg+mUyGJE7Yvn2CbAaKpYDpyTb9gwGpdIpCvk0SRZ39cbDECWBjugpZrv/lJbzuouVzMmYiIiIiz0W3ook8i20HZvjRw6P88z27iRPL4u4sxsCtW8Z5+ZndBL7HwyMVurMBucCl1grJpX1M2MAYmEkCwNBXCGhHCQbDdCOkJ+9TnZygVO4CYw5toNmZPXGMi7EJ1ia0wpiUazCH9tvBWsIwJJX2McYntgmOMUSxxXfA4pAkMUliObh/kv4FnTUwSWLxHQdrY6xxiaM2iY1JBVnCKMRgO3vkOAYS2+nAZqHValI5WOPzv30lS/sKcz0cIiIicpo5mmygYCPyPFhreWRkmv+zcS+PjVbI+9Buh7h+wCP7qvQV0uybavCP71qLPbRI/8N/dSvuQIbHxhpcsqSLe3ZOcmZ/jqFyGs9As9kgm82TWAsYbNzCOAGtqE3gujQjSz5wmKlMky2WiZMEB4tjPOK4jef5YAxhHOMZh8ha4rCF8VKkXMA42DgksYDj4ViLdTobf9o4odNmrdN1jSShHbZwjYefCjrtn4E4Cvnd9Wu4cGn3nL7/IiIicno6mmygW9FEngdjDOcsLHPOwjJRnPDYyCTWuCRJ0mnLbFw8x3D2UGn2Of/3U1fzvfv38qF/fgCAUsanKxtgrWGmHVPM5TtrZIA4SXBxaLZjAs9j68E6S7sz7NwxTleXi8EA5tC6nc7sigVsYnFdh5nKFJlcHtdP4bkOYDszNxbCMMR4LukA4jghjmIcB2wUE4UhQTqNxSEVZIhsjMUSxhGeF1DI+go1IiIiMi8o2IgcJc91OHe453md+/oLFtJXTPP1u3axZf8MI9NNShmfR0cqXLSkTDbw+Onmg1yxogdrOvvabNpXZdVgEc+z5POQzRWAhGatSiafg8Tiej5YS2RjHOtSKJSJ4wjPNdTrVTLZPNZ2bn3zfR/XgVseHeeyZXmM42DwcD0P1+3M+jRbddJeijhqY9IZXDcAYFExfRzfSREREZFjR13RRI6zy5f38MrV/URJwtLeLFv3z3D+cImZVkwzjLlsWTeeY4gTi+86nLWgiO8Ykhg2HgTHczHGIZPLMTUxSRi2iZKEgwcPErabtBt14jjkwP4pYiwHdzVpzMzQbDZoR032j06RNRGvO6ef3lSLVeWE87sTBgoetXqVxDiMH2hQD1uksjlcA60o5onHDvDjW/fM9dsnIiIi8rxoxkbkBHjpil7OX1Tu3G4WJWzdP8OvX76EdpzwvQf2sbCc4f7dU5w9VKA359EOW0TNBi8/o0CcWDy3syfNvQeAA1Ves6qXAwdhKO9QyGRphTHl3iJRu8XAsjz16RnuHocLh0v0Dub41K9dQiZwD6vJWssXf/wEG3dNctW6M1i7rIe/v20HNo6pHJxk8ZIcLiFJkuA4+h2IiIiInNwUbEROgJ58ig+9eiVfvm07AO97xZm89+VnAPDWtUv4i+8/xBl9OaJDndNu3V4nAC5fBinf0IrBJAmrPNgRQXfa8k+//wsMlbN4ruGhPVPsm25x/64JHt47Ta5c4hW9Hq4xnL2wdESogc66od9++ZkcmGmxoJQBOhuNfv3OnRQKacIkwno+37/9Qf7LSy84UW+ViIiIyAuirmgiJ1CcWP7vI6O88qx+Ut7Pwsb9u6f4H997mGI2wMFigCiK8TyHOIrBdTEWbBLz0jN6eOfLV3XaMz+NTfumeWRflRW9WSJrGK+1ePWawedd4z9u2M4P7nmcmemE+gysPjPgC7+5/hlfT0REROR4UVe042DneI0lPbm5LkPmOdcxvO7cBUccv2C4zLKeNHunQ9qJJe06uMYhTsDxfGxiWd6f4y2XLWFF/7PvJ7NqQYlVC0rPes6zOafH56t7ExafUeSmmQpdk23u2DLKujOPrFtERETkZKEb55+nnw81cWJ5bF9ljqqRU9H7XnUW1WaEawwp38F1O02e22GT/3TeQj7yn9Y8Z6g5Fn7vyw+wDbhla4Wzy5AEGR7dvO24v66IiIjIi6Fg8wK1ophcoAkvOXaW9eb44CuXMX1wgnZkSaylHUY4U1WuuWTRCVvA/56XdFo8v3p1D92lLOVchgfG6ifktUVEREReKAWbFygbeCzuyc51GXKKecWaIXoHejhYa1Fpxky2LW+7+pITWsNb//MrWA1UK5Nks1lcLJt3ttk5On5C6xARERE5Ggo2IicRx3F41ep+BgspMr5DO0qYaoYnvIbrfu1cNo8kVBotrGPY2oRf/fwdJ7QOERERkaOhYHOMVJshJ1mDOZmn3nzxIl65sszurRNk2jNsHp0+4TW8Ys1CVmcg8Hwcx6UNrDjhVYiIiIg8f1okcowE3pEZcboRUsr4c1CNzGf5TMBvvHQVv37FSu599Alq8Yn/a+p7Lh99zzq+eNN2Ks0YgDe+XF0BRURE5OSlGZtjJOW5R+zzoVAjL4YxhovPXsWV550xJ6+/ckE3H3jVSuphzGW98J9e9bI5qUNERETk+dCMzRyptyOy6qomJ6EoTvBchzCK2TJWZVEp4PVXXkzad5/7ySIiIiJzRD9ZzxGFGjlZTdTadGV9vvrTzSzqKfLx159LIRvMdVkiIiIiz0o/XZ8EZloR1loKad26JnOvv9jZx+bdr1g9x5WIiIiIPH9aY3MSSHkOlWYEQJJY6u1ojisSEREREZlfFGxOAr7rsLCcAcBxzNPepjbTUtgREREREXkmCjbzRD6luwZFRERERJ6Jgs08ZK3l4T2T/O87ts91KSIiIiIiJwUFm3nosX3TYAzLezobJo5Xmzywa3KOqxIRERERmTtHFWyuv/56Lr30UgqFAv39/bzxjW9k06ZNh53TbDa59tpr6enpIZ/Pc8011zA2NnZMiz7drRkqc87CMuvO7AdgZHyaN3zxdjaPVbl72/gcVyciIiIicuIdVbC5+eabufbaa7njjju44YYbCMOQ17zmNdRqtdlzPvShD/G9732Pb33rW9x8882MjIzwpje96ZgXLj9z7tIBdnzqasoZjx88tJePfONOdo3XnvuJIiIiIiKnCGOttS/0yQcOHKC/v5+bb76ZK6+8kunpafr6+vja177GL/3SLwHw+OOPc9ZZZ7FhwwYuv/zyI67RarVotVqzn1cqFYaHh5menqZYLL7Q0k5beybrbB6tcOZAnkXd+bkuR0REROSkd6Daoq+Qmusy5GlUKhVKpdLzygYvao3N9PQ0AN3d3QBs3LiRMAxZv3797DmrV69m8eLFbNiw4Wmvcf3111MqlWY/hoeHX0xJp71FXVl+YdUAX7x5K3/+vYdpaU8cERERkWfVmw/YX2nOdRnyIr3gYJMkCR/84Ae54oorOOeccwAYHR0lCALK5fJh5w4MDDA6Ovq01/nIRz7C9PT07Mfu3btfaElySGwtlXrIppGD/MvGnXNdjoiIiMhJzRhD/MJvYpKTxAveHOXaa6/l4Ycf5tZbb31RBaRSKVIpTf0dS77rMFjK8uo1C3jtOYNzXY6IiIjISW+wmMZaizFmrkuRF+gFBZv3v//9fP/73+eWW25h0aJFs8cHBwdpt9tMTU0dNmszNjbG4KB+wD6R/tvVZ+kvpswr1lpueXATu/eNcfvNM3zyj19BJpMi5blzXZqIiJwGKs2IVhTTX0jPdSnyAh3VrWjWWt7//vfz7W9/mx//+McsW7bssMcvvvhifN/nxhtvnD22adMmdu3axbp1645NxfK8KNTIfDI+02LvRJ1Pfn0r//2mGX5g4T2f/wn/eOPDPLHnwFyXJyIip4Fi2mNsuvXcJ8pJ66hmbK699lq+9rWv8Z3vfIdCoTC7bqZUKpHJZCiVSrzrXe/iuuuuo7u7m2KxyAc+8AHWrVv3tB3RREQAevIpyKf43HvXMlGt4noul525iPGZFptGxlk51wWKiMgpzxijzmjz3FG1e36mWYCvfOUrvOMd7wA6G3R++MMf5utf/zqtVourrrqKL37xi8/7VrSjaekmIiIiInKsjE41GCxn5roMeYqjyQYvah+b40HBRkRERETmwv5qU2tsTjInbB8bEREREZFTQbUZohXK85uCjYiIiIic9gppH9fRj8bzmUZPRERERARIeZqzmc8UbERERETktPfY3il++ujuuS5DXoQXtEGniIiIiMipZGlfgbMWlue6DHkRNGMjIiIiIqe1ajNk+8GZuS5DXiQFGxERERE5bVlruX/zbtYMlea6FHmRFGxERERE5LQ1VW+zfd+BuS5DjgEFGxERERE5bXXlUrztNWvnugw5BhRsRERERERk3lOwERERERGReU/BRkRERERE5j0FGxERERERmfcUbEREREREZN5TsBERERERkXlPwUZEREREROY9BRsREREREZn3FGxERERERGTeU7AREREREZF5T8FGRERERETmPQUbERERERGZ9xRsRERERERk3lOwERERERGReU/BRkRERERE5j0FGxERERERmfcUbEREREREZN5TsBERERERkXlPwUZEREREROY9BRsREREREZn3FGxERERERGTeU7AREREREZF5T8FGRERERETmPQUbERERERGZ945bsPnCF77A0qVLSafTrF27lrvuuut4vZSIiIiIiJzmjkuw+eY3v8l1113Hxz/+ce69917OP/98rrrqKvbv3388Xk5ERERERE5zxyXYfPazn+Xd734373znO1mzZg1f+tKXyGazfPnLXz4eLyciIiIiIqe5Yx5s2u02GzduZP369T97Ecdh/fr1bNiw4YjzW60WlUrlsA8REREREZGjccyDzcGDB4njmIGBgcOODwwMMDo6esT5119/PaVSafZjeHj4WJckIiIiIiKnuDnvivaRj3yE6enp2Y/du3fPdUkiIiIiIjLPeMf6gr29vbiuy9jY2GHHx8bGGBwcPOL8VCpFKpU61mWIiIiIiMhp5JjP2ARBwMUXX8yNN944eyxJEm688UbWrVt3rF9ORERERETk2M/YAFx33XW8/e1v55JLLuGyyy7j85//PLVajXe+853H4+VEREREROQ0d1yCzVve8hYOHDjAxz72MUZHR7ngggv40Y9+dERDARERERERkWPBWGvtXBfxVJVKhVKpxPT0NMVica7LERERERGROXI02WDOu6KJiIiIiIi8WAo2IiIiIiIy7ynYiIiIiIjIvKdgIyIiIiIi856CjYiIiIiIzHsKNiIiIiIiMu8p2IiIiIiIyLynYCMiIiIiIvOego2IiIiIiMx7CjYiIiIiIjLvKdiIiIiIiMi8p2AjIiIiIiLznoKNiIiIiIjMewo2IiIiIiIy7ynYiIiIiIjIvKdgIyIiIiIi856CjYiIiIiIzHsKNsdZpRnOdQkiIiIiIqc8BZvjrJj257oEEREREZFTnoKNiIiIiIjMewo2IiIiIiIy7ynYiIiIiIjIvKdgIyIiIiIi856CjYiIiIiIzHsKNseZtZatY9MAPDpSmeNqREREREROTQo2x5m1YLAArB4szB6van8bEREREZFjRsHmOHMcw/KB8uyfn1TQ/jYiIiIiIseMgo2IiIiIiMx7CjYiIiIiIjLvKdiIiIiIiMi8p2AjIiIiIiLznoKNiIiIiIjMewo2IiIiIiIy7ynYiIiIiIjIvOfNdQE/z9rOZpaVSmWOKxERERERkbn0ZCZ4MiM8m5Mu2FSrVQCGh4fnuBIRERERETkZVKtVSqXSs55j7POJPydQkiSMjIxQKBQwxsx1OaeFSqXC8PAwu3fvplgsznU5py2Nw8lB43By0DicHDQOJweNw8lDY3HiWWupVqsMDQ3hOM++iuakm7FxHIdFixbNdRmnpWKxqL+kJwGNw8lB43By0DicHDQOJweNw8lDY3FiPddMzZPUPEBEREREROY9BRsREREREZn3FGyEVCrFxz/+cVKp1FyXclrTOJwcNA4nB43DyUHjcHLQOJw8NBYnt5OueYCIiIiIiMjR0oyNiIiIiIjMewo2IiIiIiIy7ynYiIiIiIjIvKdgIyIiIiIi856CjYiIiIiIzHsKNqeRP//zP+clL3kJ2WyWcrn8tOcYY474+MY3vnHYOTfddBMXXXQRqVSKFStW8NWvfvX4F38KeT7jsGvXLq6++mqy2Sz9/f38wR/8AVEUHXaOxuHYW7p06RHf/5/61KcOO+fBBx/kZS97Gel0muHhYT796U/PUbWnti984QssXbqUdDrN2rVrueuuu+a6pFPan/zJnxzxvb969erZx5vNJtdeey09PT3k83muueYaxsbG5rDiU8Mtt9zC61//eoaGhjDG8K//+q+HPW6t5WMf+xgLFiwgk8mwfv16Nm/efNg5ExMTvPWtb6VYLFIul3nXu97FzMzMCfwq5r/nGod3vOMdR/z9eO1rX3vYORqHk4OCzWmk3W7z5je/mfe+973Pet5XvvIV9u3bN/vxxje+cfax7du3c/XVV/OKV7yC+++/nw9+8IP81m/9Fv/+7/9+nKs/dTzXOMRxzNVXX0273eb222/nH/7hH/jqV7/Kxz72sdlzNA7Hz5/+6Z8e9v3/gQ98YPaxSqXCa17zGpYsWcLGjRv5zGc+w5/8yZ/wt3/7t3NY8annm9/8Jtdddx0f//jHuffeezn//PO56qqr2L9//1yXdko7++yzD/vev/XWW2cf+9CHPsT3vvc9vvWtb3HzzTczMjLCm970pjms9tRQq9U4//zz+cIXvvC0j3/605/mL//yL/nSl77EnXfeSS6X46qrrqLZbM6e89a3vpVHHnmEG264ge9///vccsstvOc97zlRX8Ip4bnGAeC1r33tYX8/vv71rx/2uMbhJGHltPOVr3zFlkqlp30MsN/+9ref8bl/+Id/aM8+++zDjr3lLW+xV1111TGs8PTwTOPwgx/8wDqOY0dHR2eP/fVf/7UtFou21WpZazUOx8uSJUvs5z73uWd8/Itf/KLt6uqaHQdrrf2jP/oju2rVqhNQ3enjsssus9dee+3s53Ec26GhIXv99dfPYVWnto9//OP2/PPPf9rHpqamrO/79lvf+tbssccee8wCdsOGDSeowlPfz//7mySJHRwctJ/5zGdmj01NTdlUKmW//vWvW2utffTRRy1g77777tlzfvjDH1pjjN27d+8Jq/1U8nQ/B7397W+3b3jDG57xORqHk4dmbOQI1157Lb29vVx22WV8+ctfxj5lD9cNGzawfv36w86/6qqr2LBhw4ku85S1YcMGzj33XAYGBmaPXXXVVVQqFR555JHZczQOx8enPvUpenp6uPDCC/nMZz5z2C2AGzZs4MorryQIgtljV111FZs2bWJycnIuyj3ltNttNm7ceNj3t+M4rF+/Xt/fx9nmzZsZGhpi+fLlvPWtb2XXrl0AbNy4kTAMDxuT1atXs3jxYo3JcbR9+3ZGR0cPe99LpRJr166dfd83bNhAuVzmkksumT1n/fr1OI7DnXfeecJrPpXddNNN9Pf3s2rVKt773vcyPj4++5jG4eThzXUBcnL50z/9U175yleSzWb5v//3//K+972PmZkZfvd3fxeA0dHRw37gBhgYGKBSqdBoNMhkMnNR9inlmd7jJx97tnM0Di/O7/7u73LRRRfR3d3N7bffzkc+8hH27dvHZz/7WaDzvi9btuyw5zx1bLq6uk54zaeagwcPEsfx035/P/7443NU1alv7dq1fPWrX2XVqlXs27ePT3ziE7zsZS/j4YcfZnR0lCAIjlgTODAwMPv/JDn2nnxvn+7vwlP/Lejv7z/scc/z6O7u1tgcQ6997Wt505vexLJly9i6dSt//Md/zOte9zo2bNiA67oah5OIgs0891//63/lL/7iL571nMcee+ywRaDP5qMf/ejsny+88EJqtRqf+cxnZoONPL1jPQ5y7BzN2Fx33XWzx8477zyCIOC3f/u3uf7660mlUse7VJE587rXvW72z+eddx5r165lyZIl/PM//7N+USKnvV/5lV+Z/fO5557LeeedxxlnnMFNN93Eq171qjmsTH6egs089+EPf5h3vOMdz3rO8uXLX/D1165dy5/92Z/RarVIpVIMDg4e0QlnbGyMYrF4Wv/jdyzHYXBw8IgOUE++54ODg7P/1Tg8Py9mbNauXUsURezYsYNVq1Y94/sOPxsbeXF6e3txXfdp32e9xydOuVxm5cqVbNmyhVe/+tW0222mpqYOm7XRmBxfT763Y2NjLFiwYPb42NgYF1xwwew5P99UI4oiJiYmNDbH0fLly+nt7WXLli286lWv0jicRBRs5rm+vj76+vqO2/Xvv/9+urq6Zn9bvW7dOn7wgx8cds4NN9zAunXrjlsN88GxHId169bx53/+5+zfv392avuGG26gWCyyZs2a2XM0Ds/Pixmb+++/H8dxZsdh3bp1/Lf/9t8IwxDf94HO+75q1SrdhnaMBEHAxRdfzI033jjbkTFJEm688Ube//73z21xp5GZmRm2bt3Kb/zGb3DxxRfj+z433ngj11xzDQCbNm1i165d+n/OcbRs2TIGBwe58cYbZ4NMpVLhzjvvnO2quW7dOqampti4cSMXX3wxAD/+8Y9JkoS1a9fOVemnvD179jA+Pj4bODUOJ5G57l4gJ87OnTvtfffdZz/xiU/YfD5v77vvPnvffffZarVqrbX2u9/9rv27v/s7+9BDD9nNmzfbL37xizabzdqPfexjs9fYtm2bzWaz9g/+4A/sY489Zr/whS9Y13Xtj370o7n6suad5xqHKIrsOeecY1/zmtfY+++/3/7oRz+yfX199iMf+cjsNTQOx97tt99uP/e5z9n777/fbt261f7TP/2T7evrs29729tmz5mamrIDAwP2N37jN+zDDz9sv/GNb9hsNmv/5m/+Zg4rP/V84xvfsKlUyn71q1+1jz76qH3Pe95jy+XyYZ0C5dj68Ic/bG+66Sa7fft2e9ttt9n169fb3t5eu3//fmuttb/zO79jFy9ebH/84x/be+65x65bt86uW7dujque/6rV6uy/AYD97Gc/a++77z67c+dOa621n/rUp2y5XLbf+c537IMPPmjf8IY32GXLltlGozF7jde+9rX2wgsvtHfeeae99dZb7Zlnnml/9Vd/da6+pHnp2cahWq3a3//937cbNmyw27dvt//xH/9hL7roInvmmWfaZrM5ew2Nw8lBweY08va3v90CR3z85Cc/sdZ2WhNecMEFNp/P21wuZ88//3z7pS99ycZxfNh1fvKTn9gLLrjABkFgly9fbr/yla+c+C9mHnuucbDW2h07dtjXve51NpPJ2N7eXvvhD3/YhmF42HU0DsfWxo0b7dq1a22pVLLpdNqeddZZ9pOf/ORh/3BZa+0DDzxgX/rSl9pUKmUXLlxoP/WpT81Rxae2//k//6ddvHixDYLAXnbZZfaOO+6Y65JOaW95y1vsggULbBAEduHChfYtb3mL3bJly+zjjUbDvu9977NdXV02m83aX/zFX7T79u2bw4pPDT/5yU+e9t+Dt7/97dbaTsvnj370o3ZgYMCmUin7qle9ym7atOmwa4yPj9tf/dVftfl83haLRfvOd75z9hdl8vw82zjU63X7mte8xvb19Vnf9+2SJUvsu9/97iN+0aJxODkYa5/Sy1dERERERGQe0j42IiIiIiIy7ynYiIiIiIjIvKdgIyIiIiIi856CjYiIiIiIzHsKNiIiIiIiMu8p2IiIiIiIyLynYCMiIiIiIvOego2IiIiIiMx7CjYiIiIiIjLvKdiIiIiIiMi8p2AjIiIiIiLz3v8PrUHmlGy7078AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot the GeoDataFrame using GeoPandas' plot function\n",
+    "fig, ax = plt.subplots(figsize=(10, 10))\n",
+    "\n",
+    "# Plot the GeoDataFrame using GeoPandas' plot function\n",
+    "gdf.plot(ax=ax,xlim=bbox[:2], ylim=bbox[2:])\n",
+    "# Show the plot\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook has the code and an explanation about how to download .shp files for 2010 census tracts from UCSB. Including instructions about how to get an API key (very simple).